### PR TITLE
Add PATCH /v1/agents/me endpoint for self-service profile updates

### DIFF
--- a/service/handlers.go
+++ b/service/handlers.go
@@ -542,6 +542,64 @@ func (h *Handlers) RotateToken(w http.ResponseWriter, r *http.Request) {
 }
 
 // ---------------------------------------------------------------------------
+// PATCH /v1/agents/me
+// ---------------------------------------------------------------------------
+
+type UpdateProfileRequest struct {
+	Name string `json:"name"`
+}
+
+func (h *Handlers) UpdateProfile(w http.ResponseWriter, r *http.Request) {
+	agent := AgentFromContext(r.Context())
+
+	var req UpdateProfileRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	// Validate name
+	if req.Name == "" {
+		jsonError(w, "name is required", http.StatusBadRequest)
+		return
+	}
+	if len(req.Name) > 100 {
+		jsonError(w, "name must be 100 characters or less", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.store.UpdateAgentProfile(agent.ID, req.Name); err != nil {
+		log.Printf("ERROR: update profile: %v", err)
+		jsonError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Return updated agent info
+	updated, err := h.store.GetAgent(agent.ID)
+	if err != nil || updated == nil {
+		log.Printf("ERROR: get updated agent: %v", err)
+		jsonError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("updated profile for agent %s: name=%s", agent.ID, req.Name)
+
+	jsonResponse(w, http.StatusOK, AgentInfoResponse{
+		AgentID:         updated.ID,
+		Name:            updated.Name,
+		Hostname:        updated.Hostname,
+		OS:              updated.OS,
+		Arch:            updated.Arch,
+		OpenClawVersion: updated.OpenClawVersion,
+		EncryptTool:     updated.EncryptTool,
+		Status:          updated.Status,
+		QuotaBytes:      updated.QuotaBytes,
+		UsedBytes:       updated.UsedBytes,
+		CreatedAt:       updated.CreatedAt.Format("2006-01-02T15:04:05Z"),
+	})
+}
+
+// ---------------------------------------------------------------------------
 // Admin handlers
 // ---------------------------------------------------------------------------
 

--- a/service/main.go
+++ b/service/main.go
@@ -99,6 +99,7 @@ func buildHandler(store DataStore, s3client *S3Client, cfg *Config) http.Handler
 
 	// Agent management (auth-only, no active requirement)
 	mux.Handle("GET /v1/agents/me", Auth(store, http.HandlerFunc(h.AgentInfo)))
+	mux.Handle("PATCH /v1/agents/me", Auth(store, http.HandlerFunc(h.UpdateProfile)))
 	mux.Handle("POST /v1/agents/me/rotate-token", Auth(store, http.HandlerFunc(h.RotateToken)))
 
 	// Admin endpoints (protected by X-API-Key header)

--- a/service/store.go
+++ b/service/store.go
@@ -17,6 +17,7 @@ type DataStore interface {
 	LookupAgentByToken(token string) (*Agent, error)
 	GetAgent(id string) (*Agent, error)
 	RotateAgentToken(agentID, newTokenHash string) error
+	UpdateAgentProfile(agentID, name string) error
 	UpdateUsedBytes(agentID string) error
 	ListAgents(status string) ([]Agent, error)
 	UpdateAgentStatus(id, status string) error

--- a/service/store_dynamo.go
+++ b/service/store_dynamo.go
@@ -174,6 +174,24 @@ func (s *DynamoStore) RotateAgentToken(agentID, newTokenHash string) error {
 	return err
 }
 
+func (s *DynamoStore) UpdateAgentProfile(agentID, name string) error {
+	_, err := s.client.UpdateItem(context.Background(), &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.agentsTable),
+		Key: map[string]types.AttributeValue{
+			"id": &types.AttributeValueMemberS{Value: agentID},
+		},
+		UpdateExpression: aws.String("SET #n = :name"),
+		ExpressionAttributeNames: map[string]string{
+			"#n": "name",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":name": &types.AttributeValueMemberS{Value: name},
+		},
+		ConditionExpression: aws.String("attribute_exists(id)"),
+	})
+	return err
+}
+
 func (s *DynamoStore) UpdateUsedBytes(agentID string) error {
 	// In DynamoDB we recalculate by querying backups
 	_, totalBytes, err := s.CountBackups(agentID)

--- a/service/store_sqlite.go
+++ b/service/store_sqlite.go
@@ -146,6 +146,11 @@ func (s *SQLiteStore) RotateAgentToken(agentID, newTokenHash string) error {
 	return err
 }
 
+func (s *SQLiteStore) UpdateAgentProfile(agentID, name string) error {
+	_, err := s.db.Exec(`UPDATE agents SET name = ? WHERE id = ?`, name, agentID)
+	return err
+}
+
 func (s *SQLiteStore) UpdateUsedBytes(agentID string) error {
 	_, err := s.db.Exec(`
 		UPDATE agents SET used_bytes = (


### PR DESCRIPTION
## Summary

Adds `PATCH /v1/agents/me` endpoint to allow agents to update their own name after registration.

## Changes

- **Store interface:** Added `UpdateAgentProfile(agentID, name string) error`
- **SQLite:** Implemented UPDATE query
- **DynamoDB:** Implemented UpdateItem with name attribute
- **Handler:** New `UpdateProfile` handler with validation (name required, max 100 chars)
- **Route:** Wired up `PATCH /v1/agents/me` (auth-only, no active status required)

## API

```
PATCH /v1/agents/me
Authorization: Bearer <agent_token>
Content-Type: application/json

{
  "name": "Architect"
}
```

**Response 200:**
```json
{
  "agent_id": "ag_abc123",
  "name": "Architect",
  ...
}
```

## Testing

Build succeeds locally. Would benefit from unit tests for the new handler.

Fixes #2