### PR TITLE
feat: add invite codes for auto-approved agent registration

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -47,11 +47,21 @@ backup service, and installs a daily scheduler:
 bash {baseDir}/scripts/setup.sh
 ```
 
+If you have an **invite code**, set it before running setup so the agent is immediately
+activated (no admin approval wait):
+
+```bash
+OPENCLAW_BACKUP_INVITE_CODE=ZNTH-XXXXXXXX bash {baseDir}/scripts/setup.sh
+```
+
 Setup is fully automatic and requires no human input. It will:
 1. Generate an age keypair (master encryption key)
 2. Register this agent with the backup service
 3. Install a daily scheduler (launchd on macOS, systemd timer on Linux, cron fallback)
-4. Run the first backup immediately
+4. Run the first backup immediately (if agent is active)
+
+**Without an invite code**, the agent starts in `pending` status and requires admin
+approval before backups can run. The scheduler will retry on schedule once approved.
 
 ## Commands
 
@@ -130,8 +140,10 @@ Set via `openclaw.json` under `skills.entries.backup`:
 - `max_backup_size_mb` -- Safety limit on uncompressed backup size (default: 500)
 
 Note: Registration is open (no API key needed). New agents start in **pending** status
-and require admin approval before backups can run. The backup scheduler handles this
-gracefully — it will retry on schedule until the agent is approved.
+and require admin approval before backups can run — unless an invite code is provided
+at registration time (see Setup above), in which case the agent is immediately **active**.
+The backup scheduler handles pending status gracefully — it will retry on schedule until
+the agent is approved.
 
 ## What gets backed up
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -223,6 +223,8 @@ if [[ -f "$STATE_DIR/agent.token" ]]; then
 else
     info "Registering with backup service at $BACKUP_SERVICE_URL ..."
 
+    INVITE_CODE="${OPENCLAW_BACKUP_INVITE_CODE:-}"
+
     REGISTER_PAYLOAD=$(jq -n \
         --arg name "$AGENT_NAME" \
         --arg hostname "$AGENT_HOSTNAME" \
@@ -232,16 +234,31 @@ else
         --arg fingerprint "$MACHINE_FINGERPRINT" \
         --arg encrypt_tool "$ENCRYPT_TOOL" \
         --arg public_key "$(cat "$STATE_DIR/recipient.txt" 2>/dev/null || echo '')" \
-        '{
-            agent_name: $name,
-            hostname: $hostname,
-            os: $os,
-            arch: $arch,
-            openclaw_version: $version,
-            machine_fingerprint: $fingerprint,
-            encrypt_tool: $encrypt_tool,
-            public_key: $public_key
-        }')
+        --arg invite_code "$INVITE_CODE" \
+        'if $invite_code != "" then
+            {
+                agent_name: $name,
+                hostname: $hostname,
+                os: $os,
+                arch: $arch,
+                openclaw_version: $version,
+                machine_fingerprint: $fingerprint,
+                encrypt_tool: $encrypt_tool,
+                public_key: $public_key,
+                invite_code: $invite_code
+            }
+        else
+            {
+                agent_name: $name,
+                hostname: $hostname,
+                os: $os,
+                arch: $arch,
+                openclaw_version: $version,
+                machine_fingerprint: $fingerprint,
+                encrypt_tool: $encrypt_tool,
+                public_key: $public_key
+            }
+        end')
 
     REGISTER_RESPONSE=$(curl -sf -X POST \
         -H "Content-Type: application/json" \

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -235,30 +235,7 @@ else
         --arg encrypt_tool "$ENCRYPT_TOOL" \
         --arg public_key "$(cat "$STATE_DIR/recipient.txt" 2>/dev/null || echo '')" \
         --arg invite_code "$INVITE_CODE" \
-        'if $invite_code != "" then
-            {
-                agent_name: $name,
-                hostname: $hostname,
-                os: $os,
-                arch: $arch,
-                openclaw_version: $version,
-                machine_fingerprint: $fingerprint,
-                encrypt_tool: $encrypt_tool,
-                public_key: $public_key,
-                invite_code: $invite_code
-            }
-        else
-            {
-                agent_name: $name,
-                hostname: $hostname,
-                os: $os,
-                arch: $arch,
-                openclaw_version: $version,
-                machine_fingerprint: $fingerprint,
-                encrypt_tool: $encrypt_tool,
-                public_key: $public_key
-            }
-        end')
+        '{agent_name: $name, hostname: $hostname, os: $os, arch: $arch, openclaw_version: $version, machine_fingerprint: $fingerprint, encrypt_tool: $encrypt_tool, public_key: $public_key} | if $invite_code != "" then . + {invite_code: $invite_code} else . end')
 
     REGISTER_RESPONSE=$(curl -sf -X POST \
         -H "Content-Type: application/json" \

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -754,8 +754,9 @@ func (h *Handlers) AdminCreateInviteCode(w http.ResponseWriter, r *http.Request)
 	}
 
 	ic := &InviteCode{
-		Code:    code,
-		MaxUses: req.MaxUses,
+		Code:      code,
+		MaxUses:   req.MaxUses,
+		CreatedAt: time.Now().UTC(),
 	}
 	if req.ExpiresInHours > 0 {
 		exp := time.Now().UTC().Add(time.Duration(req.ExpiresInHours) * time.Hour)

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"log"
+	"math/big"
 	"net/http"
 	"strconv"
 	"time"
@@ -20,14 +22,15 @@ type Handlers struct {
 // ---------------------------------------------------------------------------
 
 type RegisterRequest struct {
-	AgentName      string `json:"agent_name"`
-	Hostname       string `json:"hostname"`
-	OS             string `json:"os"`
-	Arch           string `json:"arch"`
+	AgentName       string `json:"agent_name"`
+	Hostname        string `json:"hostname"`
+	OS              string `json:"os"`
+	Arch            string `json:"arch"`
 	OpenClawVersion string `json:"openclaw_version"`
-	Fingerprint    string `json:"machine_fingerprint"`
-	EncryptTool    string `json:"encrypt_tool"`
-	PublicKey      string `json:"public_key"`
+	Fingerprint     string `json:"machine_fingerprint"`
+	EncryptTool     string `json:"encrypt_tool"`
+	PublicKey       string `json:"public_key"`
+	InviteCode      string `json:"invite_code,omitempty"`
 }
 
 type RegisterResponse struct {
@@ -74,6 +77,22 @@ func (h *Handlers) Register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Determine status based on invite code
+	status := "pending"
+	if req.InviteCode != "" {
+		valid, err := h.store.UseInviteCode(req.InviteCode)
+		if err != nil {
+			log.Printf("ERROR: use invite code: %v", err)
+			jsonError(w, "internal error", http.StatusInternalServerError)
+			return
+		}
+		if !valid {
+			jsonError(w, "invalid or expired invite code", http.StatusBadRequest)
+			return
+		}
+		status = "active"
+	}
+
 	agent := &Agent{
 		ID:              agentID,
 		Name:            req.AgentName,
@@ -83,8 +102,8 @@ func (h *Handlers) Register(w http.ResponseWriter, r *http.Request) {
 		OpenClawVersion: req.OpenClawVersion,
 		Fingerprint:     req.Fingerprint,
 		EncryptTool:     req.EncryptTool,
-		PublicKey:        req.PublicKey,
-		Status:          "pending",
+		PublicKey:       req.PublicKey,
+		Status:          status,
 		QuotaBytes:      h.config.DefaultQuotaBytes,
 	}
 
@@ -94,12 +113,12 @@ func (h *Handlers) Register(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("registered agent %s (%s) from %s", agentID, req.AgentName, req.Hostname)
+	log.Printf("registered agent %s (%s) from %s status=%s", agentID, req.AgentName, req.Hostname, status)
 
 	jsonResponse(w, http.StatusCreated, RegisterResponse{
 		AgentID:      agentID,
 		Token:        token,
-		Status:       "pending",
+		Status:       status,
 		QuotaMB:      h.config.DefaultQuotaBytes / (1024 * 1024),
 		BackupPrefix: agentID + "/",
 	})
@@ -667,6 +686,122 @@ func (h *Handlers) AdminSuspendAgent(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("admin suspended agent %s", id)
 	jsonResponse(w, http.StatusOK, map[string]string{"status": "suspended"})
+}
+
+// ---------------------------------------------------------------------------
+// Admin invite code handlers
+// ---------------------------------------------------------------------------
+
+// generateInviteCode returns a code of the form "ZNTH-XXXXXXXX" where X is
+// a random uppercase alphanumeric character.
+func generateInviteCode() (string, error) {
+	const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	b := make([]byte, 8)
+	for i := range b {
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(chars))))
+		if err != nil {
+			return "", err
+		}
+		b[i] = chars[n.Int64()]
+	}
+	return "ZNTH-" + string(b), nil
+}
+
+type CreateInviteCodeRequest struct {
+	MaxUses        int `json:"max_uses"`
+	ExpiresInHours int `json:"expires_in_hours"`
+}
+
+type InviteCodeResponse struct {
+	Code      string  `json:"code"`
+	MaxUses   int     `json:"max_uses"`
+	UseCount  int     `json:"use_count"`
+	ExpiresAt *string `json:"expires_at,omitempty"`
+	CreatedAt string  `json:"created_at"`
+	RevokedAt *string `json:"revoked_at,omitempty"`
+}
+
+func inviteCodeToResponse(ic InviteCode) InviteCodeResponse {
+	resp := InviteCodeResponse{
+		Code:      ic.Code,
+		MaxUses:   ic.MaxUses,
+		UseCount:  ic.UseCount,
+		CreatedAt: ic.CreatedAt.Format(time.RFC3339),
+	}
+	if ic.ExpiresAt != nil {
+		s := ic.ExpiresAt.Format(time.RFC3339)
+		resp.ExpiresAt = &s
+	}
+	if ic.RevokedAt != nil {
+		s := ic.RevokedAt.Format(time.RFC3339)
+		resp.RevokedAt = &s
+	}
+	return resp
+}
+
+func (h *Handlers) AdminCreateInviteCode(w http.ResponseWriter, r *http.Request) {
+	var req CreateInviteCodeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		jsonError(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	code, err := generateInviteCode()
+	if err != nil {
+		log.Printf("ERROR: generate invite code: %v", err)
+		jsonError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	ic := &InviteCode{
+		Code:    code,
+		MaxUses: req.MaxUses,
+	}
+	if req.ExpiresInHours > 0 {
+		exp := time.Now().UTC().Add(time.Duration(req.ExpiresInHours) * time.Hour)
+		ic.ExpiresAt = &exp
+	}
+
+	if err := h.store.CreateInviteCode(ic); err != nil {
+		log.Printf("ERROR: create invite code: %v", err)
+		jsonError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	log.Printf("admin created invite code %s (max_uses=%d)", code, req.MaxUses)
+	jsonResponse(w, http.StatusCreated, inviteCodeToResponse(*ic))
+}
+
+func (h *Handlers) AdminListInviteCodes(w http.ResponseWriter, r *http.Request) {
+	codes, err := h.store.ListInviteCodes()
+	if err != nil {
+		log.Printf("ERROR: list invite codes: %v", err)
+		jsonError(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	resp := make([]InviteCodeResponse, len(codes))
+	for i, ic := range codes {
+		resp[i] = inviteCodeToResponse(ic)
+	}
+	jsonResponse(w, http.StatusOK, resp)
+}
+
+func (h *Handlers) AdminRevokeInviteCode(w http.ResponseWriter, r *http.Request) {
+	code := r.PathValue("code")
+	if code == "" {
+		jsonError(w, "code required", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.store.RevokeInviteCode(code); err != nil {
+		log.Printf("ERROR: revoke invite code %s: %v", code, err)
+		jsonError(w, "invite code not found or already revoked", http.StatusNotFound)
+		return
+	}
+
+	log.Printf("admin revoked invite code %s", code)
+	jsonResponse(w, http.StatusOK, map[string]string{"revoked": code})
 }
 
 // ---------------------------------------------------------------------------

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -993,3 +993,265 @@ func TestAPIKeyAuth_RotatedKey(t *testing.T) {
 		t.Error("new-key should be accepted during rotation")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Invite code tests
+// ---------------------------------------------------------------------------
+
+func TestRegisterWithValidInviteCode(t *testing.T) {
+	h, cleanup := setupTestService(t)
+	defer cleanup()
+
+	// Create an invite code directly in the store
+	ic := &InviteCode{
+		Code:    "ZNTH-TESTCODE",
+		MaxUses: 5,
+	}
+	if err := h.store.CreateInviteCode(ic); err != nil {
+		t.Fatalf("CreateInviteCode: %v", err)
+	}
+
+	body := `{"agent_name":"invite-agent","hostname":"testhost","os":"Linux","arch":"x86_64","invite_code":"ZNTH-TESTCODE"}`
+	req := httptest.NewRequest("POST", "/v1/agents/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.Register(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp RegisterResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if resp.Status != "active" {
+		t.Errorf("expected status active with valid invite code, got %s", resp.Status)
+	}
+
+	// Verify agent is active in store
+	agent, err := h.store.LookupAgentByToken(resp.Token)
+	if err != nil || agent == nil {
+		t.Fatalf("expected agent, got nil or err: %v", err)
+	}
+	if agent.Status != "active" {
+		t.Errorf("expected agent status active, got %s", agent.Status)
+	}
+}
+
+func TestRegisterWithInvalidInviteCode(t *testing.T) {
+	h, cleanup := setupTestService(t)
+	defer cleanup()
+
+	body := `{"agent_name":"bad-code-agent","hostname":"testhost","invite_code":"ZNTH-BADCODE1"}`
+	req := httptest.NewRequest("POST", "/v1/agents/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.Register(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for invalid invite code, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]string
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["error"] != "invalid or expired invite code" {
+		t.Errorf("expected specific error message, got: %s", resp["error"])
+	}
+}
+
+func TestRegisterWithExhaustedInviteCode(t *testing.T) {
+	h, cleanup := setupTestService(t)
+	defer cleanup()
+
+	// Create a single-use invite code and exhaust it
+	ic := &InviteCode{
+		Code:    "ZNTH-ONEUSE11",
+		MaxUses: 1,
+	}
+	if err := h.store.CreateInviteCode(ic); err != nil {
+		t.Fatalf("CreateInviteCode: %v", err)
+	}
+
+	// Use it once
+	valid, err := h.store.UseInviteCode("ZNTH-ONEUSE11")
+	if err != nil || !valid {
+		t.Fatalf("expected valid on first use, got valid=%v err=%v", valid, err)
+	}
+
+	// Try to register with exhausted code
+	body := `{"agent_name":"exhausted-agent","hostname":"testhost","invite_code":"ZNTH-ONEUSE11"}`
+	req := httptest.NewRequest("POST", "/v1/agents/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.Register(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for exhausted invite code, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRegisterWithExpiredInviteCode(t *testing.T) {
+	h, cleanup := setupTestService(t)
+	defer cleanup()
+
+	// Create an already-expired invite code
+	past := time.Now().UTC().Add(-1 * time.Hour)
+	ic := &InviteCode{
+		Code:      "ZNTH-EXPIRED1",
+		MaxUses:   0,
+		ExpiresAt: &past,
+	}
+	if err := h.store.CreateInviteCode(ic); err != nil {
+		t.Fatalf("CreateInviteCode: %v", err)
+	}
+
+	body := `{"agent_name":"expired-agent","hostname":"testhost","invite_code":"ZNTH-EXPIRED1"}`
+	req := httptest.NewRequest("POST", "/v1/agents/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.Register(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for expired invite code, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRegisterWithoutInviteCode_StillPending(t *testing.T) {
+	h, cleanup := setupTestService(t)
+	defer cleanup()
+
+	body := `{"agent_name":"no-code-agent","hostname":"testhost"}`
+	req := httptest.NewRequest("POST", "/v1/agents/register", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.Register(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp RegisterResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.Status != "pending" {
+		t.Errorf("expected status pending without invite code, got %s", resp.Status)
+	}
+}
+
+func TestAdminCreateInviteCode(t *testing.T) {
+	h, cleanup := setupTestService(t)
+	defer cleanup()
+
+	body := `{"max_uses": 10, "expires_in_hours": 48}`
+	req := httptest.NewRequest("POST", "/v1/admin/invite-codes", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	h.AdminCreateInviteCode(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp InviteCodeResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+
+	if resp.Code == "" {
+		t.Error("expected non-empty code")
+	}
+	if len(resp.Code) != 13 { // "ZNTH-" + 8 chars = 13
+		t.Errorf("expected code length 13, got %d: %s", len(resp.Code), resp.Code)
+	}
+	if resp.Code[:5] != "ZNTH-" {
+		t.Errorf("expected code to start with ZNTH-, got %s", resp.Code)
+	}
+	if resp.MaxUses != 10 {
+		t.Errorf("expected max_uses 10, got %d", resp.MaxUses)
+	}
+	if resp.ExpiresAt == nil {
+		t.Error("expected expires_at to be set")
+	}
+}
+
+func TestAdminListInviteCodes(t *testing.T) {
+	h, cleanup := setupTestService(t)
+	defer cleanup()
+
+	// Create some codes
+	for _, code := range []string{"ZNTH-LIST0001", "ZNTH-LIST0002"} {
+		ic := &InviteCode{Code: code, MaxUses: 5}
+		if err := h.store.CreateInviteCode(ic); err != nil {
+			t.Fatalf("CreateInviteCode: %v", err)
+		}
+	}
+
+	req := httptest.NewRequest("GET", "/v1/admin/invite-codes", nil)
+	w := httptest.NewRecorder()
+
+	h.AdminListInviteCodes(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp []InviteCodeResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if len(resp) != 2 {
+		t.Errorf("expected 2 invite codes, got %d", len(resp))
+	}
+}
+
+func TestAdminRevokeInviteCode(t *testing.T) {
+	h, cleanup := setupTestService(t)
+	defer cleanup()
+
+	ic := &InviteCode{Code: "ZNTH-REVOKE01", MaxUses: 10}
+	if err := h.store.CreateInviteCode(ic); err != nil {
+		t.Fatalf("CreateInviteCode: %v", err)
+	}
+
+	// Revoke it
+	req := httptest.NewRequest("DELETE", "/v1/admin/invite-codes/ZNTH-REVOKE01", nil)
+	req.SetPathValue("code", "ZNTH-REVOKE01")
+	w := httptest.NewRecorder()
+
+	h.AdminRevokeInviteCode(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify code is revoked (UseInviteCode returns false)
+	valid, err := h.store.UseInviteCode("ZNTH-REVOKE01")
+	if err != nil {
+		t.Fatalf("UseInviteCode: %v", err)
+	}
+	if valid {
+		t.Error("expected revoked code to be invalid")
+	}
+}
+
+func TestAdminRevokeInviteCode_NotFound(t *testing.T) {
+	h, cleanup := setupTestService(t)
+	defer cleanup()
+
+	req := httptest.NewRequest("DELETE", "/v1/admin/invite-codes/ZNTH-NOTFOUND", nil)
+	req.SetPathValue("code", "ZNTH-NOTFOUND")
+	w := httptest.NewRecorder()
+
+	h.AdminRevokeInviteCode(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for non-existent code, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/service/main.go
+++ b/service/main.go
@@ -107,6 +107,11 @@ func buildHandler(store DataStore, s3client *S3Client, cfg *Config) http.Handler
 	mux.Handle("POST /v1/admin/agents/{id}/approve", APIKeyAuth(cfg.AdminAPIKey, http.HandlerFunc(h.AdminApproveAgent)))
 	mux.Handle("POST /v1/admin/agents/{id}/suspend", APIKeyAuth(cfg.AdminAPIKey, http.HandlerFunc(h.AdminSuspendAgent)))
 
+	// Admin invite code endpoints
+	mux.Handle("POST /v1/admin/invite-codes", APIKeyAuth(cfg.AdminAPIKey, http.HandlerFunc(h.AdminCreateInviteCode)))
+	mux.Handle("GET /v1/admin/invite-codes", APIKeyAuth(cfg.AdminAPIKey, http.HandlerFunc(h.AdminListInviteCodes)))
+	mux.Handle("DELETE /v1/admin/invite-codes/{code}", APIKeyAuth(cfg.AdminAPIKey, http.HandlerFunc(h.AdminRevokeInviteCode)))
+
 	// Health
 	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)

--- a/service/store.go
+++ b/service/store.go
@@ -31,11 +31,26 @@ type DataStore interface {
 	DeleteBackup(agentID, timestamp string) (*Backup, error)
 	DeleteAllBackups(agentID string) ([]Backup, error)
 	UndeleteBackup(agentID, timestamp string) error
+
+	// Invite codes
+	CreateInviteCode(code *InviteCode) error
+	UseInviteCode(code string) (valid bool, err error) // atomic: check + increment use count
+	ListInviteCodes() ([]InviteCode, error)
+	RevokeInviteCode(code string) error
 }
 
 // ---------------------------------------------------------------------------
 // Shared model types
 // ---------------------------------------------------------------------------
+
+type InviteCode struct {
+	Code      string
+	MaxUses   int        // 0 = unlimited
+	UseCount  int
+	ExpiresAt *time.Time // nil = no expiry
+	CreatedAt time.Time
+	RevokedAt *time.Time
+}
 
 type Agent struct {
 	ID              string

--- a/service/store_dynamo.go
+++ b/service/store_dynamo.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -611,7 +612,11 @@ func (s *DynamoStore) UseInviteCode(code string) (bool, error) {
 	})
 	if err != nil {
 		// ConditionalCheckFailedException means the code was used concurrently
-		return false, nil
+		var ccfe *types.ConditionalCheckFailedException
+		if errors.As(err, &ccfe) {
+			return false, nil
+		}
+		return false, fmt.Errorf("update invite code use_count: %w", err)
 	}
 
 	return true, nil

--- a/service/store_dynamo.go
+++ b/service/store_dynamo.go
@@ -41,6 +41,19 @@ type dynamoAgent struct {
 	CreatedAt       string `dynamodbav:"created_at"`
 }
 
+// dynamoInviteCode is stored in the agents table with id = "INVITE#<code>"
+// and item_type = "invite_code" to distinguish from agent items.
+type dynamoInviteCode struct {
+	ID        string  `dynamodbav:"id"`       // "INVITE#<code>"
+	ItemType  string  `dynamodbav:"item_type"` // "invite_code"
+	Code      string  `dynamodbav:"code"`
+	MaxUses   int     `dynamodbav:"max_uses"`
+	UseCount  int     `dynamodbav:"use_count"`
+	ExpiresAt *int64  `dynamodbav:"expires_at_epoch,omitempty"` // Unix timestamp, nil = no expiry
+	CreatedAt string  `dynamodbav:"created_at"`
+	RevokedAt string  `dynamodbav:"revoked_at,omitempty"`
+}
+
 type dynamoBackup struct {
 	AgentID         string `dynamodbav:"agent_id"`
 	Timestamp       string `dynamodbav:"timestamp"`
@@ -215,10 +228,12 @@ func (s *DynamoStore) UpdateUsedBytes(agentID string) error {
 func (s *DynamoStore) ListAgents(status string) ([]Agent, error) {
 	input := &dynamodb.ScanInput{
 		TableName: aws.String(s.agentsTable),
+		// Exclude invite code items (which have item_type = "invite_code")
+		FilterExpression: aws.String("attribute_not_exists(item_type)"),
 	}
 
 	if status != "" {
-		input.FilterExpression = aws.String("#s = :s")
+		input.FilterExpression = aws.String("attribute_not_exists(item_type) AND #s = :s")
 		input.ExpressionAttributeNames = map[string]string{
 			"#s": "status",
 		}
@@ -246,7 +261,7 @@ func (s *DynamoStore) ListAgents(status string) ([]Agent, error) {
 func (s *DynamoStore) CountAgentsByStatus(status string) (int, error) {
 	out, err := s.client.Scan(context.Background(), &dynamodb.ScanInput{
 		TableName:        aws.String(s.agentsTable),
-		FilterExpression: aws.String("#s = :s"),
+		FilterExpression: aws.String("attribute_not_exists(item_type) AND #s = :s"),
 		ExpressionAttributeNames: map[string]string{
 			"#s": "status",
 		},
@@ -503,6 +518,160 @@ func (s *DynamoStore) UndeleteBackup(agentID, timestamp string) error {
 	}
 
 	_ = s.UpdateUsedBytes(agentID)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Invite code operations
+// ---------------------------------------------------------------------------
+
+func (s *DynamoStore) CreateInviteCode(code *InviteCode) error {
+	item := dynamoInviteCode{
+		ID:        "INVITE#" + code.Code,
+		ItemType:  "invite_code",
+		Code:      code.Code,
+		MaxUses:   code.MaxUses,
+		UseCount:  0,
+		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if code.ExpiresAt != nil {
+		epoch := code.ExpiresAt.Unix()
+		item.ExpiresAt = &epoch
+	}
+
+	av, err := attributevalue.MarshalMap(item)
+	if err != nil {
+		return fmt.Errorf("marshal invite code: %w", err)
+	}
+
+	_, err = s.client.PutItem(context.Background(), &dynamodb.PutItemInput{
+		TableName: aws.String(s.agentsTable),
+		Item:      av,
+	})
+	return err
+}
+
+func (s *DynamoStore) UseInviteCode(code string) (bool, error) {
+	key := "INVITE#" + code
+
+	// First, fetch the item to check validity
+	out, err := s.client.GetItem(context.Background(), &dynamodb.GetItemInput{
+		TableName: aws.String(s.agentsTable),
+		Key: map[string]types.AttributeValue{
+			"id": &types.AttributeValueMemberS{Value: key},
+		},
+	})
+	if err != nil {
+		return false, fmt.Errorf("get invite code: %w", err)
+	}
+	if out.Item == nil {
+		return false, nil
+	}
+
+	var ic dynamoInviteCode
+	if err := attributevalue.UnmarshalMap(out.Item, &ic); err != nil {
+		return false, fmt.Errorf("unmarshal invite code: %w", err)
+	}
+
+	// Check revoked
+	if ic.RevokedAt != "" {
+		return false, nil
+	}
+
+	// Check expiry
+	if ic.ExpiresAt != nil && time.Now().Unix() > *ic.ExpiresAt {
+		return false, nil
+	}
+
+	// Check max uses (0 = unlimited)
+	if ic.MaxUses > 0 && ic.UseCount >= ic.MaxUses {
+		return false, nil
+	}
+
+	// Atomic increment with condition: use_count must still be same value (optimistic lock)
+	// Also re-check max_uses and expiry in condition
+	condExpr := "attribute_exists(id) AND attribute_not_exists(revoked_at)"
+	exprAttrValues := map[string]types.AttributeValue{
+		":inc":      &types.AttributeValueMemberN{Value: "1"},
+		":cur":      &types.AttributeValueMemberN{Value: strconv.Itoa(ic.UseCount)},
+	}
+
+	if ic.MaxUses > 0 {
+		condExpr += " AND use_count = :cur"
+	}
+
+	_, err = s.client.UpdateItem(context.Background(), &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.agentsTable),
+		Key: map[string]types.AttributeValue{
+			"id": &types.AttributeValueMemberS{Value: key},
+		},
+		UpdateExpression:    aws.String("SET use_count = use_count + :inc"),
+		ConditionExpression: aws.String(condExpr),
+		ExpressionAttributeValues: exprAttrValues,
+	})
+	if err != nil {
+		// ConditionalCheckFailedException means the code was used concurrently
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (s *DynamoStore) ListInviteCodes() ([]InviteCode, error) {
+	out, err := s.client.Scan(context.Background(), &dynamodb.ScanInput{
+		TableName:        aws.String(s.agentsTable),
+		FilterExpression: aws.String("item_type = :t"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":t": &types.AttributeValueMemberS{Value: "invite_code"},
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("scan invite codes: %w", err)
+	}
+
+	codes := make([]InviteCode, 0, len(out.Items))
+	for _, item := range out.Items {
+		var ic dynamoInviteCode
+		if err := attributevalue.UnmarshalMap(item, &ic); err != nil {
+			return nil, fmt.Errorf("unmarshal invite code: %w", err)
+		}
+		result := InviteCode{
+			Code:     ic.Code,
+			MaxUses:  ic.MaxUses,
+			UseCount: ic.UseCount,
+		}
+		result.CreatedAt, _ = time.Parse(time.RFC3339, ic.CreatedAt)
+		if ic.ExpiresAt != nil {
+			t := time.Unix(*ic.ExpiresAt, 0).UTC()
+			result.ExpiresAt = &t
+		}
+		if ic.RevokedAt != "" {
+			t, err := time.Parse(time.RFC3339, ic.RevokedAt)
+			if err == nil {
+				result.RevokedAt = &t
+			}
+		}
+		codes = append(codes, result)
+	}
+	return codes, nil
+}
+
+func (s *DynamoStore) RevokeInviteCode(code string) error {
+	key := "INVITE#" + code
+	_, err := s.client.UpdateItem(context.Background(), &dynamodb.UpdateItemInput{
+		TableName: aws.String(s.agentsTable),
+		Key: map[string]types.AttributeValue{
+			"id": &types.AttributeValueMemberS{Value: key},
+		},
+		UpdateExpression:    aws.String("SET revoked_at = :ra"),
+		ConditionExpression: aws.String("attribute_exists(id) AND attribute_not_exists(revoked_at)"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":ra": &types.AttributeValueMemberS{Value: time.Now().UTC().Format(time.RFC3339)},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("revoke invite code %s: %w", code, err)
+	}
 	return nil
 }
 

--- a/service/store_sqlite.go
+++ b/service/store_sqlite.go
@@ -80,6 +80,21 @@ func migrateSQLite(db *sql.DB) error {
 	// Migration: add deleted_at column for soft-delete
 	_, _ = db.Exec(`ALTER TABLE backups ADD COLUMN deleted_at TEXT`)
 
+	// Migration: invite codes table
+	_, err = db.Exec(`
+		CREATE TABLE IF NOT EXISTS invite_codes (
+			code       TEXT PRIMARY KEY,
+			max_uses   INTEGER NOT NULL DEFAULT 0,
+			use_count  INTEGER NOT NULL DEFAULT 0,
+			expires_at TEXT,
+			created_at TEXT NOT NULL DEFAULT (datetime('now')),
+			revoked_at TEXT
+		)
+	`)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -327,5 +342,119 @@ func (s *SQLiteStore) UndeleteBackup(agentID, timestamp string) error {
 		return fmt.Errorf("backup not found or not deleted")
 	}
 	_ = s.UpdateUsedBytes(agentID)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Invite code operations
+// ---------------------------------------------------------------------------
+
+func (s *SQLiteStore) CreateInviteCode(code *InviteCode) error {
+	var expiresAt interface{}
+	if code.ExpiresAt != nil {
+		expiresAt = code.ExpiresAt.UTC().Format("2006-01-02 15:04:05")
+	}
+	_, err := s.db.Exec(`
+		INSERT INTO invite_codes (code, max_uses, use_count, expires_at)
+		VALUES (?, ?, 0, ?)`,
+		code.Code, code.MaxUses, expiresAt,
+	)
+	return err
+}
+
+func (s *SQLiteStore) UseInviteCode(code string) (bool, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback()
+
+	row := tx.QueryRow(`
+		SELECT max_uses, use_count, expires_at, revoked_at
+		FROM invite_codes WHERE code = ?`, code)
+
+	var maxUses, useCount int
+	var expiresAtStr, revokedAtStr *string
+	if err := row.Scan(&maxUses, &useCount, &expiresAtStr, &revokedAtStr); err != nil {
+		if err.Error() == "sql: no rows in result set" {
+			return false, nil
+		}
+		return false, err
+	}
+
+	// Check revoked
+	if revokedAtStr != nil {
+		return false, nil
+	}
+
+	// Check expiry
+	if expiresAtStr != nil {
+		exp, err := time.Parse("2006-01-02 15:04:05", *expiresAtStr)
+		if err == nil && time.Now().UTC().After(exp) {
+			return false, nil
+		}
+	}
+
+	// Check max uses (0 = unlimited)
+	if maxUses > 0 && useCount >= maxUses {
+		return false, nil
+	}
+
+	// Atomic increment
+	_, err = tx.Exec(`UPDATE invite_codes SET use_count = use_count + 1 WHERE code = ?`, code)
+	if err != nil {
+		return false, err
+	}
+
+	return true, tx.Commit()
+}
+
+func (s *SQLiteStore) ListInviteCodes() ([]InviteCode, error) {
+	rows, err := s.db.Query(`
+		SELECT code, max_uses, use_count, expires_at, created_at, revoked_at
+		FROM invite_codes ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var codes []InviteCode
+	for rows.Next() {
+		var ic InviteCode
+		var expiresAtStr, createdAtStr string
+		var expiresAtPtr, revokedAtPtr *string
+		if err := rows.Scan(&ic.Code, &ic.MaxUses, &ic.UseCount, &expiresAtPtr, &createdAtStr, &revokedAtPtr); err != nil {
+			return nil, err
+		}
+		ic.CreatedAt, _ = time.Parse("2006-01-02 15:04:05", createdAtStr)
+		_ = expiresAtStr
+		if expiresAtPtr != nil {
+			t, err := time.Parse("2006-01-02 15:04:05", *expiresAtPtr)
+			if err == nil {
+				ic.ExpiresAt = &t
+			}
+		}
+		if revokedAtPtr != nil {
+			t, err := time.Parse("2006-01-02 15:04:05", *revokedAtPtr)
+			if err == nil {
+				ic.RevokedAt = &t
+			}
+		}
+		codes = append(codes, ic)
+	}
+	return codes, rows.Err()
+}
+
+func (s *SQLiteStore) RevokeInviteCode(code string) error {
+	res, err := s.db.Exec(`
+		UPDATE invite_codes SET revoked_at = datetime('now')
+		WHERE code = ? AND revoked_at IS NULL`, code)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("invite code not found or already revoked: %s", code)
+	}
 	return nil
 }

--- a/service/store_sqlite.go
+++ b/service/store_sqlite.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -376,7 +377,7 @@ func (s *SQLiteStore) UseInviteCode(code string) (bool, error) {
 	var maxUses, useCount int
 	var expiresAtStr, revokedAtStr *string
 	if err := row.Scan(&maxUses, &useCount, &expiresAtStr, &revokedAtStr); err != nil {
-		if err.Error() == "sql: no rows in result set" {
+		if errors.Is(err, sql.ErrNoRows) {
 			return false, nil
 		}
 		return false, err
@@ -421,13 +422,12 @@ func (s *SQLiteStore) ListInviteCodes() ([]InviteCode, error) {
 	var codes []InviteCode
 	for rows.Next() {
 		var ic InviteCode
-		var expiresAtStr, createdAtStr string
+		var createdAtStr string
 		var expiresAtPtr, revokedAtPtr *string
 		if err := rows.Scan(&ic.Code, &ic.MaxUses, &ic.UseCount, &expiresAtPtr, &createdAtStr, &revokedAtPtr); err != nil {
 			return nil, err
 		}
 		ic.CreatedAt, _ = time.Parse("2006-01-02 15:04:05", createdAtStr)
-		_ = expiresAtStr
 		if expiresAtPtr != nil {
 			t, err := time.Parse("2006-01-02 15:04:05", *expiresAtPtr)
 			if err == nil {


### PR DESCRIPTION
## Summary

Implements invite codes so agents registering with a valid code are immediately set to `active` status, bypassing the manual admin approval flow.

Closes #4

## Changes

- **`service/store.go`**: Added `InviteCode` model and 4 new `DataStore` interface methods (`CreateInviteCode`, `UseInviteCode`, `ListInviteCodes`, `RevokeInviteCode`)
- **`service/store_sqlite.go`**: Implemented invite codes with a new `invite_codes` table. `UseInviteCode` is atomic (transaction-based)
- **`service/store_dynamo.go`**: Implemented invite codes using `INVITE#<code>` prefixed items in the agents table. Atomic `UseInviteCode` via conditional update. Agent scans updated to exclude invite code items
- **`service/handlers.go`**: Added `invite_code` field to `RegisterRequest`, updated `Register` to check/consume codes, added `AdminCreateInviteCode` / `AdminListInviteCodes` / `AdminRevokeInviteCode` handlers and `generateInviteCode()` helper (format: `ZNTH-XXXXXXXX`)
- **`service/main.go`**: Registered 3 new admin invite code routes
- **`scripts/setup.sh`**: Reads optional `OPENCLAW_BACKUP_INVITE_CODE` env var and includes it in the register payload
- **`SKILL.md`**: Documented invite code flow
- **`service/handlers_test.go`**: 9 new tests covering all invite code scenarios

## Test Results

All 38 tests pass (`go test ./...`).